### PR TITLE
impl: `eth_getTransactionReceipt` method

### DIFF
--- a/src/rpc/calls.ts
+++ b/src/rpc/calls.ts
@@ -58,6 +58,7 @@ Methods.set('eth_getBlockTransactionCountByHash', {
 Methods.set('eth_getTransactionByBlockHashAndIndex', {
   method: 'eth_getTransactionByBlockHashAndIndex',
   handler: getTransactionsByBlockHashAndIndexHandler,
+})
 
 Methods.set('eth_getTransactionReceipt', {
   method: 'eth_getTransactionReceipt',

--- a/src/rpc/calls.ts
+++ b/src/rpc/calls.ts
@@ -5,6 +5,7 @@ import { chainIdHandler } from './calls/chainId'
 import { maxPriorityFeePerGasHandler } from './calls/maxPriorityFeePerGas'
 import { blockNumberHandler } from './calls/blockNumber'
 import { getStorageAtHandler } from './calls/getStorageAt'
+import { getTransactionReceiptHandler } from './calls/getTransactionReceipt'
 
 const router: Router = Router()
 
@@ -27,6 +28,11 @@ Methods.set('eth_blockNumber', {
 Methods.set('eth_getStorageAt', {
   method: 'eth_getStorageAt',
   handler: getStorageAtHandler,
+})
+
+Methods.set('eth_getTransactionReceipt', {
+  method: 'eth_getTransactionReceipt',
+  handler: getTransactionReceiptHandler,
 })
 
 router.post('/', async function (req: ParsedRequest, res: Response) {

--- a/src/rpc/calls/getTransactionReceipt.ts
+++ b/src/rpc/calls/getTransactionReceipt.ts
@@ -99,12 +99,12 @@ export async function getTransactionReceiptHandler(
     jsonrpc: '2.0',
     id: 1,
     result: {
-      transactionHash: result1.transaction_hash,
+      transactionHash: transactionHash,
       blockHash: result1.block_hash!,
       blockNumber: '0x' + result1.block_number!.toString(16),
       logs: await Promise.all(
         result1.events.map(async (event, i) => ({
-          transactionHash: result1.transaction_hash,
+          transactionHash: transactionHash,
           address: await getEthAddressFromSnAddress(event.from_address),
           blockHash: result1.block_hash!,
           blockNumber: '0x' + result1.block_number!.toString(16),

--- a/src/rpc/calls/getTransactionReceipt.ts
+++ b/src/rpc/calls/getTransactionReceipt.ts
@@ -1,0 +1,70 @@
+import { RPCError, RPCRequest, RPCResponse } from '../../types/types'
+import { callStarknet } from '../../utils/callHelper'
+
+export async function getTransactionReceiptHandler(
+  request: RPCRequest,
+): Promise<RPCResponse | RPCError> {
+  // TODO: dynamic network from env?
+
+  if (request.params.length == 0) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'params should not be empty',
+    }
+  }
+
+  const transactionHash = request.params[0] as string
+
+  const response: RPCResponse | string = await callStarknet('testnet', {
+    jsonrpc: request.jsonrpc,
+    method: 'starknet_getTransactionReceipt',
+    params: [transactionHash],
+    id: request.id,
+  })
+
+  if (typeof response === 'string') {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: response,
+    }
+  }
+
+  // TODO: use a schema validation library such as zod or manually(?) check the properties of the result object
+  const result = response.result as {
+    type: 'INVOKE' | 'L1_HANDLER' | 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT'
+    transaction_hash: string
+    actual_fee: string
+    messages_sent: unknown
+    events: unknown
+    execution_resources: unknown
+    execution_result: unknown
+    contract_address?: string // only on DEPLOY and DEPLOY_ACCOUNT transactions
+    finality_status?: 'ACCEPTED_ON_L1' | 'ACCEPTED_ON_L2' // only on non-pending transactions
+    block_hash?: string // only on non-pending transactions
+    block_number?: number // only on non-pending transactions
+    message_hash?: string // only on L1_HANDLER transactions
+  }
+
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      transactionHash: result.transaction_hash,
+      blockHash: result.block_hash ?? '0x0',
+      blockNumber: '0x' + (result.block_number ?? 0).toString(16),
+      logs: [], // TODO: transform `events` to `logs`
+      contractAddress: result.contract_address ?? null,
+      effectiveGasPrice: '0x2d7003407', // TODO: implement this
+      cumulativeGasUsed: result.actual_fee,
+      from: '0x5067c042e35881843f2b31dfc2db1f4f272ef48c', // TODO: implement this
+      gasUsed: result.actual_fee,
+      logsBloom: '0x0', // hardcoded
+      status: '0x0', // TODO: implement this
+      to: '0x3ee18b2214aff97000d974cf647e7c347e8fa585', // TODO: implement this
+      transactionIndex: '0x4e', // TODO: implement this
+      type: '0x0', // TODO: implement this
+    },
+  }
+}

--- a/src/rpc/calls/getTransactionReceipt.ts
+++ b/src/rpc/calls/getTransactionReceipt.ts
@@ -16,23 +16,23 @@ export async function getTransactionReceiptHandler(
 
   const transactionHash = request.params[0] as string
 
-  const response: RPCResponse | string = await callStarknet('testnet', {
+  const response1: RPCResponse | string = await callStarknet('testnet', {
     jsonrpc: request.jsonrpc,
     method: 'starknet_getTransactionReceipt',
     params: [transactionHash],
     id: request.id,
   })
 
-  if (typeof response === 'string') {
+  if (typeof response1 === 'string') {
     return {
       code: 7979,
       message: 'Starknet RPC error',
-      data: response,
+      data: response1,
     }
   }
 
   // TODO: expect that `callStarknet` might return an RPC error response
-  if ((response as unknown as { error: unknown }).error) {
+  if ((response1 as unknown as { error: unknown }).error) {
     return {
       code: 7979,
       message: 'Starknet RPC error',
@@ -41,72 +41,111 @@ export async function getTransactionReceiptHandler(
   }
 
   // TODO: use a schema validation library such as zod or manually(?) check the properties of the result object
-  const result = response.result as {
-    type: 'INVOKE' | 'L1_HANDLER' | 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT'
-    transaction_hash: string
-    actual_fee: {
-      amount: string
-      unit: 'WEI'
+  const result1 = response1.result as Transaction
+
+  // We return an error for pending transactions as this is the default behaviour in EVM chains.
+  // Non-pending transactions always have `block_hash` and `block_number` properties.
+  const isPendingTransaction = !('finality_status' in result1)
+  if (isPendingTransaction) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Starknet RPC error',
     }
-    messages_sent: unknown
-    events: {
-      from_address: string
-      keys: string[]
-      data: string[]
-    }[]
-    execution_resources: unknown
-    execution_result: unknown
-    contract_address?: string // only on DEPLOY and DEPLOY_ACCOUNT transactions
-    finality_status?: 'ACCEPTED_ON_L1' | 'ACCEPTED_ON_L2' // only on non-pending transactions
-    block_hash?: string // only on non-pending transactions
-    block_number?: number // only on non-pending transactions
-    message_hash?: string // only on L1_HANDLER transactions
   }
 
-  // might return an error for pending transactions because `eth_getTransactionReceipt` method doesn't work with pending transactions
+  const response2 = await callStarknet('testnet', {
+    jsonrpc: request.jsonrpc,
+    method: 'starknet_getBlockWithTxs',
+    params: [{ block_number: result1.block_number! }],
+    id: request.id,
+  })
+
+  if (typeof response2 === 'string') {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: response2,
+    }
+  }
+
+  // TODO: expect that `callStarknet` might return an RPC error response
+  if ((response2 as unknown as { error: unknown }).error) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Starknet RPC error',
+    }
+  }
+
+  const result2 = response2.result as {
+    transactions: (Transaction & { sender_address?: string })[]
+  }
+
+  const transactionIndex = result2.transactions.findIndex(
+    tx => tx.transaction_hash === result1.transaction_hash,
+  )
+
+  const senderAddress =
+    result2.transactions[transactionIndex].sender_address ??
+    '0x000000000000000000000000000000000000000000000000000000000000000'
+
   return {
     jsonrpc: '2.0',
     id: 1,
     result: {
-      transactionHash: result.transaction_hash,
-      // TODO: find what to use when block hash doesn't exist for pending transactions
-      blockHash: result.block_hash ?? '0xtodo',
-      // TODO: find what to use when block number doesn't exist for pending transactions
-      blockNumber: '0x' + (result.block_number ?? 0).toString(16),
-      // TODO: transform `events` to `logs`
-      logs: result.events.map(event => ({
-        transactionHash: result.transaction_hash,
-        // TODO: not sure if `from_address` is `address` equivalent
+      transactionHash: result1.transaction_hash,
+      blockHash: result1.block_hash!,
+      blockNumber: '0x' + result1.block_number!.toString(16),
+      logs: result1.events.map((event, i) => ({
+        transactionHash: result1.transaction_hash,
         address: event.from_address,
-        // TODO: find what to use when block hash doesn't exist for pending transactions
-        blockHash: result.block_hash ?? '0xtodo',
-        // TODO: find what to use when block number doesn't exist for pending transactions
-        blockNumber: '0x' + (result.block_number ?? 0).toString(16),
-        // TODO: find what to use for data, StarkNet events have multiple datas instead of a single one
-        data: '0xtodo',
-        // TODO: find what to use for log index
-        logIndex: '0xtodo',
+        blockHash: result1.block_hash!,
+        blockNumber: '0x' + result1.block_number!.toString(16),
+        // NOTE: hardcoded value
+        data: '0x0',
+        logIndex: '0x' + i.toString(16),
         removed: false,
-        // TODO: find what to use for topics
+        // NOTE: hardcoded value
         topics: [],
-        // TODO: find a way to get transaction index or hardcode a value
-        transactionIndex: '0xtodo',
+        transactionIndex: '0x' + transactionIndex.toString(16),
       })),
-      contractAddress: result.contract_address ?? null,
-      // TODO: find what to use as effective gas price or hardcode a value
-      effectiveGasPrice: '0xtodo',
-      cumulativeGasUsed: result.actual_fee.amount,
-      // TODO: find a way to get sender address, use null or hardcode a value
-      from: '0xtodo',
-      gasUsed: result.actual_fee.amount,
+      contractAddress: result1.contract_address ?? null,
+      effectiveGasPrice: '0x1',
+      cumulativeGasUsed: result1.actual_fee.amount,
+      from: senderAddress,
+      gasUsed: result1.actual_fee.amount,
       logsBloom: '0x0',
       status: '0x1',
-      // TODO: find a way to get contract address, use null or hardcode a value
-      to: '0xtodo',
-      // TODO: find a way to get transaction index or hardcode a value
-      transactionIndex: '0xtodo',
-      // TODO: find which one to hardcode 0x0, 0x1 or 0x2
-      type: '0xtodo',
+      // NOTE: hardcoded value
+      to: result1.contract_address
+        ? null
+        : '0x000000000000000000000000000000000000000000000000000000000000000',
+      transactionIndex: '0x' + transactionIndex.toString(16),
+      // NOTE: I noticed that basic transfers, contract creations and interactions are all transaction type 2 after EIP-1559.
+      type: '0x2',
     },
   }
+}
+
+type Transaction = {
+  type: 'INVOKE' | 'L1_HANDLER' | 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT'
+  transaction_hash: string
+  actual_fee: {
+    amount: string
+    unit: 'WEI'
+  }
+  messages_sent: unknown
+  events: {
+    from_address: string
+    keys: string[]
+    data: string[]
+  }[]
+  execution_resources: unknown
+  execution_result: unknown
+  contract_address?: string // only on DEPLOY and DEPLOY_ACCOUNT transactions
+  finality_status?: 'ACCEPTED_ON_L1' | 'ACCEPTED_ON_L2' // only on non-pending transactions
+  block_hash?: string // only on non-pending transactions
+  block_number?: number // only on non-pending transactions
+  message_hash?: string // only on L1_HANDLER transactions
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,7 +20,7 @@ export interface RPCError {
 export interface RPCResponse {
   jsonrpc: string
   id: number
-  result: string | number | boolean | Array<string | number | boolean | object>
+  result: string | number | boolean | object | Array<string | number | boolean | object>
 }
 
 export interface ResponseHandler {

--- a/tests/rpc/calls/getBalance.test.ts
+++ b/tests/rpc/calls/getBalance.test.ts
@@ -14,7 +14,7 @@ describe('Test get Balance request testnet', () => {
     )
 
     expect(typeof starkResult.result).toBe('string')
-    expect(starkResult.result).toBe('0xe35fa931a0000')
+    expect(starkResult.result).toBe('0x1550f7dca70000')
   })
 
   it('Returns invalid eth address', async () => {

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -18,7 +18,7 @@ describe('Test get transaction receipt request testnet', () => {
     expect(typeof starkResult.result).toBe('object')
     expect(starkResult.result).toMatchObject({
       transactionHash:
-        '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+        '0x054b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
       blockHash:
         '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
       blockNumber: '0xe95c8',
@@ -33,7 +33,7 @@ describe('Test get transaction receipt request testnet', () => {
           removed: false,
           topics: [],
           transactionHash:
-            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+            '0x054b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
           transactionIndex: '0x1d',
         },
         {
@@ -46,7 +46,7 @@ describe('Test get transaction receipt request testnet', () => {
           removed: false,
           topics: [],
           transactionHash:
-            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+            '0x054b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
           transactionIndex: '0x1d',
         },
         {
@@ -59,7 +59,7 @@ describe('Test get transaction receipt request testnet', () => {
           removed: false,
           topics: [],
           transactionHash:
-            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+            '0x054b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
           transactionIndex: '0x1d',
         },
       ],

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -29,13 +29,13 @@ describe('Test get transaction receipt request testnet', () => {
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
-          data: '0xtodo',
-          logIndex: '0xtodo',
+          data: '0x0',
+          logIndex: '0x0',
           removed: false,
           topics: [],
           transactionHash:
             '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
-          transactionIndex: '0xtodo',
+          transactionIndex: '0x1d',
         },
         {
           address:
@@ -43,13 +43,13 @@ describe('Test get transaction receipt request testnet', () => {
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
-          data: '0xtodo',
-          logIndex: '0xtodo',
+          data: '0x0',
+          logIndex: '0x1',
           removed: false,
           topics: [],
           transactionHash:
             '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
-          transactionIndex: '0xtodo',
+          transactionIndex: '0x1d',
         },
         {
           address:
@@ -57,26 +57,26 @@ describe('Test get transaction receipt request testnet', () => {
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
-          data: '0xtodo',
-          logIndex: '0xtodo',
+          data: '0x0',
+          logIndex: '0x2',
           removed: false,
           topics: [],
           transactionHash:
             '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
-          transactionIndex: '0xtodo',
+          transactionIndex: '0x1d',
         },
       ],
       contractAddress:
         '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
-      effectiveGasPrice: '0xtodo',
+      effectiveGasPrice: '0x1',
       cumulativeGasUsed: '0x30841e33136',
-      from: '0xtodo',
+      from: '0x000000000000000000000000000000000000000000000000000000000000000',
       gasUsed: '0x30841e33136',
       logsBloom: '0x0',
       status: '0x1',
-      to: '0xtodo',
-      transactionIndex: '0xtodo',
-      type: '0xtodo',
+      to: null,
+      transactionIndex: '0x1d',
+      type: '0x2',
     })
   })
 })

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -24,8 +24,7 @@ describe('Test get transaction receipt request testnet', () => {
       blockNumber: '0xe95c8',
       logs: [
         {
-          address:
-            '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
+          address: '0x56fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
@@ -38,8 +37,7 @@ describe('Test get transaction receipt request testnet', () => {
           transactionIndex: '0x1d',
         },
         {
-          address:
-            '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
+          address: '0x56fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
@@ -52,8 +50,7 @@ describe('Test get transaction receipt request testnet', () => {
           transactionIndex: '0x1d',
         },
         {
-          address:
-            '0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+          address: '0xd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
           blockHash:
             '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
           blockNumber: '0xe95c8',
@@ -66,8 +63,7 @@ describe('Test get transaction receipt request testnet', () => {
           transactionIndex: '0x1d',
         },
       ],
-      contractAddress:
-        '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
+      contractAddress: '0x56fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
       effectiveGasPrice: '0x1',
       cumulativeGasUsed: '0x30841e33136',
       from: '0x000000000000000000000000000000000000000000000000000000000000000',

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -7,7 +7,7 @@ describe('Test get transaction receipt request testnet', () => {
       jsonrpc: '2.0',
       method: 'eth_getTransactionReceipt',
       params: [
-        '0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0',
+        '0x054b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
       ],
       id: 1,
     }
@@ -17,17 +17,63 @@ describe('Test get transaction receipt request testnet', () => {
 
     expect(typeof starkResult.result).toBe('object')
     expect(starkResult.result).toMatchObject({
-      transactionHash: '0xtodo',
-      blockHash: '0xtodo',
-      blockNumber: '0xtodo',
-      logs: [],
-      contractAddress: null,
+      transactionHash:
+        '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+      blockHash:
+        '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
+      blockNumber: '0xe95c8',
+      logs: [
+        {
+          address:
+            '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
+          blockHash:
+            '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
+          blockNumber: '0xe95c8',
+          data: '0xtodo',
+          logIndex: '0xtodo',
+          removed: false,
+          topics: [],
+          transactionHash:
+            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+          transactionIndex: '0xtodo',
+        },
+        {
+          address:
+            '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
+          blockHash:
+            '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
+          blockNumber: '0xe95c8',
+          data: '0xtodo',
+          logIndex: '0xtodo',
+          removed: false,
+          topics: [],
+          transactionHash:
+            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+          transactionIndex: '0xtodo',
+        },
+        {
+          address:
+            '0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+          blockHash:
+            '0x583a703ef5de667b9d19f87d5cc46ac140cc3ac5b3a2991555bd7c45fd58863',
+          blockNumber: '0xe95c8',
+          data: '0xtodo',
+          logIndex: '0xtodo',
+          removed: false,
+          topics: [],
+          transactionHash:
+            '0x54b60a3d157a9b9a7d1734aaaf06db939ff5ae6b9c75e221cf8504f464ec0ef',
+          transactionIndex: '0xtodo',
+        },
+      ],
+      contractAddress:
+        '0x52c6085f07d8381577703e656fd10dc1a95cdac6f7e8cf800a216606ffee4c7',
       effectiveGasPrice: '0xtodo',
-      cumulativeGasUsed: '0xtodo',
+      cumulativeGasUsed: '0x30841e33136',
       from: '0xtodo',
-      gasUsed: '0xtodo',
+      gasUsed: '0x30841e33136',
       logsBloom: '0x0',
-      status: '0xtodo',
+      status: '0x1',
       to: '0xtodo',
       transactionIndex: '0xtodo',
       type: '0xtodo',

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -1,5 +1,5 @@
 import { getTransactionReceiptHandler } from '../../../src/rpc/calls/getTransactionReceipt'
-import { RPCResponse } from '../../../src/types/types'
+import { RPCError, RPCResponse } from '../../../src/types/types'
 
 describe('Test get transaction receipt request testnet', () => {
   it('Returns transaction receipt', async () => {
@@ -74,5 +74,35 @@ describe('Test get transaction receipt request testnet', () => {
       transactionIndex: '0x1d',
       type: '0x2',
     })
+  })
+
+  it('Returns an error for non-existent transactions', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionReceipt',
+      params: ['0x000000000000000000000000000000000000000000000000000000'],
+      id: 1,
+    }
+    const starkResult: RPCError = <RPCError>(
+      await getTransactionReceiptHandler(request)
+    )
+
+    expect(typeof starkResult.message).toBe('string')
+    expect(starkResult.message).toBe('Starknet RPC error')
+  })
+
+  it('Returns an error for missing params', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionReceipt',
+      params: [],
+      id: 1,
+    }
+    const starkResult: RPCError = <RPCError>(
+      await getTransactionReceiptHandler(request)
+    )
+
+    expect(typeof starkResult.message).toBe('string')
+    expect(starkResult.message).toBe('Starknet RPC error')
   })
 })

--- a/tests/rpc/calls/getTransactionReceipt.test.ts
+++ b/tests/rpc/calls/getTransactionReceipt.test.ts
@@ -1,0 +1,36 @@
+import { getTransactionReceiptHandler } from '../../../src/rpc/calls/getTransactionReceipt'
+import { RPCResponse } from '../../../src/types/types'
+
+describe('Test get transaction receipt request testnet', () => {
+  it('Returns transaction receipt', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionReceipt',
+      params: [
+        '0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0',
+      ],
+      id: 1,
+    }
+    const starkResult: RPCResponse = <RPCResponse>(
+      await getTransactionReceiptHandler(request)
+    )
+
+    expect(typeof starkResult.result).toBe('object')
+    expect(starkResult.result).toMatchObject({
+      transactionHash: '0xtodo',
+      blockHash: '0xtodo',
+      blockNumber: '0xtodo',
+      logs: [],
+      contractAddress: null,
+      effectiveGasPrice: '0xtodo',
+      cumulativeGasUsed: '0xtodo',
+      from: '0xtodo',
+      gasUsed: '0xtodo',
+      logsBloom: '0x0',
+      status: '0xtodo',
+      to: '0xtodo',
+      transactionIndex: '0xtodo',
+      type: '0xtodo',
+    })
+  })
+})


### PR DESCRIPTION
Here is the related issue: https://github.com/keep-starknet-strange/rosettanet/issues/37

Currently the logic and tests are implemented and run correctly. But there are some missing stuff.

I noticed that transaction receipts don't exist for pending transactions on EVM blockchains, so we might return an error if the receipt requested is for a pending transaction. This would allow us to guarantee the existence of `block_hash` and `block_number` properties.

Below are the properties which I don't know what to use for:
- `effectiveGasPrice`
- `from`
- `to`
- `transactionIndex`
- `type`

Plus, I'm not sure if `from_address` property of Starknet events are the equivalent of `address` property of EVM logs.
Each Starknet event has a `data` property that is an array of hex values, but each EVM log has a `data` property that is a single hex value. Can we use the first element in the array as the log data?
And I don't know what use instead of `logIndex` and `topics` properties of EVM logs.

Any suggestions are welcomed.