### PR TITLE
Implement getTransactionByBlockNumberAndIndex Handler with tests

### DIFF
--- a/src/rpc/calls.ts
+++ b/src/rpc/calls.ts
@@ -8,6 +8,7 @@ import { blockNumberHandler } from './calls/blockNumber'
 import { getStorageAtHandler } from './calls/getStorageAt'
 import { getBalanceHandler } from './calls/getBalance'
 import { callHandler } from './calls/call'
+import { getTransactionsByBlockHashAndIndexHandler } from './calls/getTransactionByBlockHashAndIndex'
 
 const router: Router = Router()
 
@@ -45,6 +46,11 @@ Methods.set('eth_call', {
 Methods.set('eth_getBalance', {
   method: 'eth_getBalance',
   handler: getBalanceHandler,
+})
+
+Methods.set('eth_getTransactionByBlockHashAndIndex', {
+  method: 'eth_getTransactionByBlockHashAndIndex',
+  handler: getTransactionsByBlockHashAndIndexHandler,
 })
 
 router.post('/', async function (req: ParsedRequest, res: Response) {

--- a/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
+++ b/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
@@ -113,7 +113,7 @@ export async function getTransactionsByBlockHashAndIndexHandler(
     };
     block_hash: string;
     block_number: number;
-    events: any[]; // Consider defining a more specific type for the elements in this array if possible
+    events: string[]; // Consider defining a more specific type for the elements in this array if possible
     execution_resources: {
       memory_holes: number;
       range_check_builtin_applications: number;
@@ -121,7 +121,7 @@ export async function getTransactionsByBlockHashAndIndexHandler(
     };
     execution_status: 'SUCCEEDED' | string; // Adjust as necessary to include other potential status values
     finality_status: 'ACCEPTED_ON_L1' | string; // Adjust as necessary to include other potential finality statuses
-    messages_sent: any[]; // Consider defining a more specific type for the elements in this array if possible
+    messages_sent: string[]; // Consider defining a more specific type for the elements in this array if possible
   }
 
   // Map StarkNet signature components to Ethereum's v, r, s

--- a/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
+++ b/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
@@ -32,7 +32,7 @@ export async function getTransactionsByBlockHashAndIndexHandler(
   const response: RPCResponse | string = await callStarknet(network, {
     jsonrpc: request.jsonrpc,
     method,
-    params: [blockHash],
+    params: [{ block_hash: blockHash }],
     id: request.id,
   })
 
@@ -44,13 +44,6 @@ export async function getTransactionsByBlockHashAndIndexHandler(
     }
   }
 
-  if (!response.result) {
-    return {
-      code: 7979,
-      message: 'Starknet RPC error',
-      data: 'Response from StarkNet is missing result property',
-    }
-  }
 
   const result = response.result as {
     block_hash: string;
@@ -111,13 +104,24 @@ export async function getTransactionsByBlockHashAndIndexHandler(
     }
   }
 
-  const receiptRes = response.result as {
-    type: 'INVOKE' | 'L1_HANDLER' | 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT'
-    transaction_hash: string
+  const receiptRes = transactionReceipt.result as {
+    type: 'INVOKE' | 'L1_HANDLER' | 'DECLARE' | 'DEPLOY' | 'DEPLOY_ACCOUNT';
+    transaction_hash: string;
     actual_fee: {
-      amount: string
-      unit: 'WEI'
-    }
+      amount: string;
+      unit: 'WEI';
+    };
+    block_hash: string;
+    block_number: number;
+    events: any[]; // Consider defining a more specific type for the elements in this array if possible
+    execution_resources: {
+      memory_holes: number;
+      range_check_builtin_applications: number;
+      steps: number;
+    };
+    execution_status: 'SUCCEEDED' | string; // Adjust as necessary to include other potential status values
+    finality_status: 'ACCEPTED_ON_L1' | string; // Adjust as necessary to include other potential finality statuses
+    messages_sent: any[]; // Consider defining a more specific type for the elements in this array if possible
   }
 
   // Map StarkNet signature components to Ethereum's v, r, s

--- a/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
+++ b/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
@@ -1,0 +1,103 @@
+import { RPCError, RPCRequest, RPCResponse } from '../../types/types'
+import { callStarknet } from '../../utils/callHelper'
+
+export async function getTransactionsByBlockHashAndIndexHandler(
+  request: RPCRequest,
+): Promise<RPCResponse | RPCError> {
+  const network = 'testnet'
+  const method = 'starknet_getBlockWithTxs'
+
+  if (request.params.length != 2) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'two params are expected',
+    }
+  }
+
+  // Extract the blockHash and index from the request parameters.
+  const blockHash = request.params[0] as string;
+  const index = parseInt(request.params[1] as string, 16) // Convert index from hex to integer.
+
+  const response: RPCResponse | string = await callStarknet(network, {
+    jsonrpc: request.jsonrpc,
+    method,
+    params: [blockHash],
+    id: request.id,
+  })
+
+  if (typeof response === 'string') {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: response,
+    }
+  }
+
+  // Check if the response contains an error property
+  if ('error' in response) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Starknet RPC error',
+    }
+  }
+
+  const result = response.result as {
+    block_hash: string;
+    block_number: number;
+    l1_gas_price: {
+      price_in_wei: string;
+    };
+    new_root: string;
+    parent_hash: string;
+    sequencer_address: string;
+    starknet_version: string;
+    status: 'ACCEPTED_ON_L2';
+    timestamp: number;
+    transactions: Array<{
+      calldata: string[];
+      max_fee: string;
+      nonce: string;
+      sender_address: string;
+      signature: string[];
+      transaction_hash: string;
+      type: 'INVOKE';
+      version: string;
+    }>;
+  };
+
+
+  // Attempt to retrieve the specified transaction by index.
+  const transaction = result.transactions[index];
+
+  if (!transaction) {
+    return {
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Transaction index out of bounds',
+    }
+  }
+
+  // Construct the Ethereum-like response, mapping StarkNet transaction details.
+  return {
+    jsonrpc: '2.0',
+    id: request.id,
+    result: {
+      blockHash: blockHash,
+      blockNumber: '0x' + result.block_number.toString(16),
+      from: transaction.sender_address,
+      gas: '0x0', // Placeholder, as StarkNet transactions don't directly map to gas.
+      gasPrice: '0x0', // Placeholder, StarkNet transactions use a different fee model.
+      hash: transaction.transaction_hash,
+      input: '0x' + transaction.calldata.join(''), // Concatenate calldata for simplicity.
+      nonce: '0x' + parseInt(transaction.nonce).toString(16),
+      to: '0x', // StarkNet transactions may not always have a direct 'to' field.
+      transactionIndex: '0x' + index.toString(16),
+      value: '0x0', // StarkNet transactions don't directly map to ETH value transfers.
+      v: '0x0', // Placeholder, as StarkNet signatures are different.
+      r: '0x0', // Placeholder, as StarkNet signatures are different.
+      s: '0x0', // Placeholder, as StarkNet signatures are different.
+    },
+  }
+}

--- a/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
+++ b/src/rpc/calls/getTransactionByBlockHashAndIndex.ts
@@ -122,9 +122,9 @@ export async function getTransactionsByBlockHashAndIndexHandler(
 
   // Map StarkNet signature components to Ethereum's v, r, s
   const signature = transaction.signature; // Assuming this is an array of FELT values
-  let v = '0x1b'; // Placeholder, as StarkNet does not have a direct 'v' equivalent, or use `0x1c` (27 or 28)
-  let r = signature.length > 0 ? signature[0] : '0x0'; // Map the first signature element to 'r'
-  let s = signature.length > 1 ? signature[1] : '0x0'; // Map the second signature element to 's'
+  const v = '0x1b'; // Placeholder, as StarkNet does not have a direct 'v' equivalent, or use `0x1c` (27 or 28)
+  const r = signature.length > 0 ? signature[0] : '0x0'; // Map the first signature element to 'r'
+  const s = signature.length > 1 ? signature[1] : '0x0'; // Map the second signature element to 's'
 
   // Construct the Ethereum-like response, mapping StarkNet transaction details.
   return {
@@ -142,9 +142,9 @@ export async function getTransactionsByBlockHashAndIndexHandler(
       to: '0x', // StarkNet transactions may not always have a direct 'to' field.
       transactionIndex: '0x' + index.toString(16),
       value: '0x0', // StarkNet transactions don't directly map to ETH value transfers.
-      v: v,
-      r: r,
-      s: s,
+      v,
+      r,
+      s,
     },
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,7 +20,7 @@ export interface RPCError {
 export interface RPCResponse {
   jsonrpc: string
   id: number
-  result: string | number | boolean | Array<string | number | boolean | object>
+  result: string | number | boolean | object | Array<string | number | boolean | object>
 }
 
 export interface ResponseHandler {

--- a/src/utils/callHelper.ts
+++ b/src/utils/callHelper.ts
@@ -18,6 +18,7 @@ export async function callStarknet(
         },
       },
     )
+    console.log("For method:", request.method, " Returning data from callStarknet: ", data)
     return data
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/utils/callHelper.ts
+++ b/src/utils/callHelper.ts
@@ -18,7 +18,6 @@ export async function callStarknet(
         },
       },
     )
-    console.log("For method:", request.method, " Returning data from callStarknet: ", data)
     return data
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -24,3 +24,21 @@ export function validateSnAddress(snAddress: string): boolean {
   }
   return true
 }
+
+export function validateBlockHash(blockHash: string): boolean {
+  if (!blockHash) {
+    return false;
+  }
+
+  // Ensure the block hash starts with '0x' and remove leading zeros
+  const normalizedBlockHash: string = addHexPrefix(
+    removeHexPrefix(blockHash).toLowerCase()
+  );
+
+  // StarkNet block hashes should be hex strings of variable length, typically 1 to 64 characters after '0x'
+  if (!normalizedBlockHash.match(/^(0x)?[0-9a-fA-F]{1,64}$/)) {
+    return false;
+  }
+
+  return true;
+}

--- a/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
+++ b/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
@@ -1,18 +1,13 @@
 import { getTransactionsByBlockHashAndIndexHandler } from '../../../src/rpc/calls/getTransactionByBlockHashAndIndex'
 import { RPCRequest, RPCResponse, RPCError } from '../../../src/types/types'
 
-// Mock the entire module for callHelper
-jest.mock('../../../src/utils/callHelper', () => ({
-    callStarknet: jest.fn(),
-  }));
-
 describe('Test getTransactionsByBlockHashAndIndexHandler', () => {
   it('Returns transaction details for a valid request', async () => {
     const request = {
       jsonrpc: '2.0',
       method: 'eth_getTransactionByBlockHashAndIndex',
       params: [
-        '0x7bcf1629508b7460d8adc4510ea8bbae12c87db555cff899fc17cf3688e8d4c',
+        '0x01806b8ff9e7ff189a563a07c7d18fbf5e30e4300dd4febb2779f5d56bfeef93',
         '0x02'
       ],
       id: 0,
@@ -22,24 +17,24 @@ describe('Test getTransactionsByBlockHashAndIndexHandler', () => {
     
     // Verify the structure and content of the response
     expect(typeof starkResult.result).toBe('object')
-    expect(starkResult.result).toMatchObject({
-      jsonrpc: '2.0',
+    expect(starkResult).toMatchObject({
       id: request.id,
+      jsonrpc: '2.0',
       result: {
-        blockHash: '0x1fc77fe9b65882b855e70b86e73da81a27690b39f30f2eb8dc01e8b5abd3679',
-        blockNumber: '0xe9f8f',
-        from: '0x1fc77fe9b65882b855e70b86e73da81a27690b39f30f2eb8dc01e8b5abd3679',
-        gas: '0x1643',
-        gasPrice: '0xee6b280',
-        hash: '0x13f9323288edb8bc93ef2fab2a9301351e1ef98af496710244bc9850555dc58',
-        input: '0x',
-        nonce: '0x47',
+        blockHash: '0x01806b8ff9e7ff189a563a07c7d18fbf5e30e4300dd4febb2779f5d56bfeef93',
+        blockNumber: '0xe9fc9',
+        from: '0x7497c28ff075311aee91ccbeca905698a0931077dc0556fafa7577910b4362f',
+        gas: '0x34453e2b238',
+        gasPrice: '0x0x3b9aca07',
+        hash: '0x5da9d4d4ea7aee2c95cebbe5bc99be05ef7ffeec28a979b896ad78fdc90c471',
+        input: '0x0x10x4c1337d55351eac9a0b74f3b8f0d3928e2bb781e5084686a892e66d49d510d0x34c4c150632e67baf44fc50e9a685184d72a822510a26a66f72058b5e7b28920x0',
+        nonce: '0x11d',
         to: '0x', // StarkNet transactions may not always have a direct 'to' field.
-        transactionIndex: '0x00',
+        transactionIndex: '0x2',
         value: '0x0', // StarkNet transactions don't directly map to ETH value transfers.
         v: '0x1b',
-        r: '0x6ce403ad8e4c5b2d6352c50eeff02904ad96fc5cc55a5686b48c7bec5cf89d0',
-        s: '0x2aa305967febd05a0d0a9ab32c7e84a52b082b3784e89eb535ac9ca43c68b82',
+        r: '0x33c21de8050c98f869c30fcf725cb78891c95c2b825d6b776c91d0415ad17ce',
+        s: '0x27fde752541931c319833a359c63d25abcc5b28b7ec54b8d99ec6107c581bc4',
       },
     })
   })

--- a/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
+++ b/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
@@ -1,5 +1,84 @@
 import { getTransactionsByBlockHashAndIndexHandler } from '../../../src/rpc/calls/getTransactionByBlockHashAndIndex'
-import { RPCResponse } from '../../../src/types/types'
+import { RPCRequest, RPCResponse, RPCError } from '../../../src/types/types'
 
-describe('Test getTransactionByBlockAndHashIndex request testnet', () => {
-})
+// Mock the entire module for callHelper
+jest.mock('../../../src/utils/callHelper', () => ({
+    callStarknet: jest.fn(),
+  }));
+
+describe('Test getTransactionsByBlockHashAndIndexHandler', () => {
+  it('Returns transaction details for a valid request', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionByBlockHashAndIndex',
+      params: [
+        '0x7bcf1629508b7460d8adc4510ea8bbae12c87db555cff899fc17cf3688e8d4c',
+        '0x02'
+      ],
+      id: 0,
+    }
+
+    const starkResult: RPCResponse = <RPCResponse>(await getTransactionsByBlockHashAndIndexHandler(request));
+    
+    // Verify the structure and content of the response
+    expect(typeof starkResult.result).toBe('object')
+    expect(starkResult.result).toMatchObject({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        blockHash: '0x1fc77fe9b65882b855e70b86e73da81a27690b39f30f2eb8dc01e8b5abd3679',
+        blockNumber: '0xe9f8f',
+        from: '0x1fc77fe9b65882b855e70b86e73da81a27690b39f30f2eb8dc01e8b5abd3679',
+        gas: '0x1643',
+        gasPrice: '0xee6b280',
+        hash: '0x13f9323288edb8bc93ef2fab2a9301351e1ef98af496710244bc9850555dc58',
+        input: '0x',
+        nonce: '0x47',
+        to: '0x', // StarkNet transactions may not always have a direct 'to' field.
+        transactionIndex: '0x00',
+        value: '0x0', // StarkNet transactions don't directly map to ETH value transfers.
+        v: '0x1b',
+        r: '0x6ce403ad8e4c5b2d6352c50eeff02904ad96fc5cc55a5686b48c7bec5cf89d0',
+        s: '0x2aa305967febd05a0d0a9ab32c7e84a52b082b3784e89eb535ac9ca43c68b82',
+      },
+    })
+  })
+
+  it('Returns transaction details for invalid block hash', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionByBlockHashAndIndex',
+      params: [
+        '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+        '0x0'
+      ],
+      id: 0,
+    }
+
+    const starkResult: RPCError = <RPCError>(await getTransactionsByBlockHashAndIndexHandler(request));
+    expect(starkResult).toMatchObject({
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Invalid block hash',
+    })
+  })
+
+  it ('Returns transaction details for invalid index', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      method: 'eth_getTransactionByBlockHashAndIndex',
+      params: [
+        '0x1fc77fe9b65882b855e70b86e73da81a27690b39f30f2eb8dc01e8b5abd3679',
+        '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
+      ],
+      id: 0,
+    }
+
+    const starkResult: RPCError = <RPCError>(await getTransactionsByBlockHashAndIndexHandler(request));
+    expect(starkResult).toMatchObject({
+      code: 7979,
+      message: 'Starknet RPC error',
+      data: 'Transaction index out of bounds',
+    })
+  })
+});

--- a/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
+++ b/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
@@ -1,0 +1,5 @@
+import { getTransactionsByBlockHashAndIndexHandler } from '../../../src/rpc/calls/getTransactionByBlockHashAndIndex'
+import { RPCResponse } from '../../../src/types/types'
+
+describe('Test getTransactionByBlockAndHashIndex request testnet', () => {
+})

--- a/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
+++ b/tests/rpc/calls/getTransactionByBlockHashAndIndex.test.ts
@@ -1,5 +1,5 @@
 import { getTransactionsByBlockHashAndIndexHandler } from '../../../src/rpc/calls/getTransactionByBlockHashAndIndex'
-import { RPCRequest, RPCResponse, RPCError } from '../../../src/types/types'
+import {RPCResponse, RPCError } from '../../../src/types/types'
 
 describe('Test getTransactionsByBlockHashAndIndexHandler', () => {
   it('Returns transaction details for a valid request', async () => {


### PR DESCRIPTION
Resolves #68 
Some of the fields are still missing; and I'm going through both the starknet and Eth APIs to see what those corresponding fields are.
```json
{
    "name": "starknet_getBlockWithTxs",
    "summary": "Get block information with full transactions given the block id",
    "params": [
        {
            "name": "block_id",
            "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
            "required": true,
            "schema": {
                "title": "Block id",
                "$ref": "#/components/schemas/BLOCK_ID"
            }
        }
    ],
    "result": {
        "name": "result",
        "description": "The resulting block information with full transactions",
        "schema": {
            "title": "Starknet get block with txs result",
            "oneOf": [
                {
                    "title": "Block with transactions",
                    "$ref": "#/components/schemas/BLOCK_WITH_TXS"
                },
                {
                    "title": "Pending block with transactions",
                    "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TXS"
                }
            ]
        }
    },
    "errors": [
        {
            "$ref": "#/components/errors/BLOCK_NOT_FOUND"
        }
    ]
},
```