### PR TITLE
Fix: Update account balance in testGetBalance

### DIFF
--- a/tests/rpc/calls/getBalance.test.ts
+++ b/tests/rpc/calls/getBalance.test.ts
@@ -14,7 +14,7 @@ describe('Test get Balance request testnet', () => {
     )
 
     expect(typeof starkResult.result).toBe('string')
-    expect(starkResult.result).toBe('0xe35fa931a0000')
+    expect(starkResult.result).toBe('0x1550f7dca70000')
   })
 
   it('Returns invalid eth address', async () => {


### PR DESCRIPTION
The account balance for the account changed.
Temporary fix, in future we'll probably mock this part, instead of actually calling testnet