### PR TITLE
Eth call complete

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -64,3 +64,8 @@ export interface EthereumBitSize {
   slotSize: number
   bitSize: number
 }
+
+export interface StarknetValue {
+  value: string
+  bitSize: number
+}

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -6,7 +6,7 @@ const STARKNET_CONVERTERS = new Map<string, StarknetType>()
 STARKNET_CONVERTERS.set('u256', {
   name: 'u256',
   converter: Uint256ToU256,
-})
+}) // TODO: DEPRECATE THIS
 
 export function toStarknetType(
   value: string,

--- a/src/utils/converters/typeConverters.ts
+++ b/src/utils/converters/typeConverters.ts
@@ -55,6 +55,7 @@ export function getSnSlotCount(sntype: string): number {
       return 1
     case 'core::felt252':
       return 1
+    // TODO: support custom types
     default:
       return 1 // TODO: returns 1 as default
   }
@@ -62,6 +63,7 @@ export function getSnSlotCount(sntype: string): number {
 
 // Returns relevant sn data type bits
 export function getSnValueEthBitsize(type: string): number {
+  // TODO: update new types
   switch (type) {
     case 'bool':
       return 1

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,15 +1,93 @@
-import { StarknetFunction } from '../types/types'
+import { StarknetFunction, StarknetValue } from '../types/types'
+import { U256toUint256 } from './converters/integer'
+import {
+  getSnSlotCount,
+  getSnValueEthBitsize,
+} from './converters/typeConverters'
 
 // Formats starknet rpc response into eth response
 export async function formatStarknetResponse(
-  result: Array<string>,
   fn: StarknetFunction,
+  result:
+    | string
+    | number
+    | boolean
+    | object
+    | Array<string | number | boolean | object>,
 ): Promise<string> {
   if (typeof fn.outputs === 'undefined') {
     return '0x0'
   }
 
-  // TODO
-  return ''
-  // First calculate howmuch eth slot we need, and which variables can fit on these slots with order.
+  if (!Array.isArray(result)) {
+    return '0x0'
+  }
+
+  // 1) Merge calldata parameters into one array of string
+  let readIndex = 0
+
+  const mergedValues: Array<StarknetValue> = []
+
+  for (const output of fn.outputs) {
+    // Get how many elements we gonna need for this output
+    const elementCount = getSnSlotCount(output.type)
+    if (elementCount == 1) {
+      mergedValues.push({
+        value: result[readIndex],
+        bitSize: getSnValueEthBitsize(output.type),
+      })
+      readIndex++
+      continue
+    }
+
+    const tempValues = []
+    for (let i = 0; i < elementCount; i++) {
+      const value = result[readIndex + i]
+      tempValues.push(value)
+    }
+    // TODO: We only support U256 for multi slots atm.
+    mergedValues.push({
+      value: U256toUint256(tempValues),
+      bitSize: getSnValueEthBitsize(output.type),
+    })
+
+    readIndex += elementCount
+  }
+
+  const paddedValues: Array<string> = mergedValues.map(val => padValues(val))
+
+  const packedValues: Array<string> = ['']
+  for (const val of paddedValues) {
+    const currentElementLength = packedValues[packedValues.length - 1].length
+    if (val.length + currentElementLength > 64) {
+      packedValues.push(val)
+      continue
+    }
+
+    // We do packing here
+    const currentElement = packedValues[packedValues.length - 1]
+    const packedElement = `${val}${currentElement}`
+    packedValues[packedValues.length - 1] = packedElement
+  }
+
+  // Pad last element
+  packedValues[packedValues.length - 1] =
+    packedValues[packedValues.length - 1].length == 64
+      ? packedValues[packedValues.length - 1]
+      : padValues({
+          bitSize: 256,
+          value: packedValues[packedValues.length - 1],
+        })
+
+  // Convert into one string
+
+  const ethereumResponse = packedValues.join('')
+  return `0x${ethereumResponse}`
+}
+
+// Returns padded values according to target bitsize. No hex prefix
+function padValues(value: StarknetValue): string {
+  const charCount = value.bitSize / 4
+  const valueWithoutPrefix = value.value.replace('0x', '')
+  return `${'0'.repeat(charCount - valueWithoutPrefix.length)}${valueWithoutPrefix}`
 }

--- a/src/utils/getRpc.ts
+++ b/src/utils/getRpc.ts
@@ -1,9 +1,7 @@
 export const mainnetRpc = [
   'https://starknet-mainnet.public.blastapi.io/rpc/v0_7',
 ]
-export const testnetRpc = [
-  'https://free-rpc.nethermind.io/sepolia-juno',
-]
+export const testnetRpc = ['https://free-rpc.nethermind.io/sepolia-juno']
 
 export const getRpc = (network?: string): string => {
   //TODO: NETWORK STRING TO TYPE

--- a/tests/rpc/calls/ethCall.test.ts
+++ b/tests/rpc/calls/ethCall.test.ts
@@ -25,6 +25,8 @@ describe('Test Eth call request testnet', () => {
     }
     // TODO: update test variables
     const result: RPCResponse = <RPCResponse>await ethCallHandler(request)
-    expect(typeof result !== 'undefined').toBe(true) // remove this test
+    expect(result.result).toBe(
+      '0x000000000000000000000000000000000000000000000000016345785d8a0000',
+    )
   })
 })


### PR DESCRIPTION
Completes `eth_call` method.

Now, we can read Starknet contract values with Ethereum rpc inputs. It only supports basic types now.